### PR TITLE
Skip rendering when gobag set is empty

### DIFF
--- a/web/js/ui/checklistRenderer.js
+++ b/web/js/ui/checklistRenderer.js
@@ -72,6 +72,8 @@ export function RenderGobag(gobagItemRegistry, gobagItems, ids, title) {
         }
     }
 
+    if (set.size === 0) return;
+
     const gobag = /** @type {string[]} */ ([...set]);
 
     const checklist = /** @type {DocumentFragment} */ (checklistTemplate.content.cloneNode(true));


### PR DESCRIPTION
Add an early return in RenderGobag when the computed `set` has size 0. This avoids creating the `gobag` array and cloning the checklist template when there are no items to render, preventing unnecessary DOM work.

Example test: I select only a city.

Old:
<img width="1920" height="938" alt="image" src="https://github.com/user-attachments/assets/dfb6d4c4-70c9-4cb6-9b91-846d9b6b2308" />

New:
<img width="1920" height="938" alt="image" src="https://github.com/user-attachments/assets/b7681916-1176-412d-9aa5-0a14ed1e18e1" />
