### PR TITLE
Validate form submission and show toast

### DIFF
--- a/web/js/controllers/formController.js
+++ b/web/js/controllers/formController.js
@@ -23,6 +23,7 @@
 
 
 import * as formRenderer from "../ui/formRenderer.js";
+import * as toastNotification from "../ui/toastNotification.js";
 
 /** @typedef {{ locationSelected: string, hazardSelected: string, specialNeedsSelected: string[]}} UserInput */
 /** @typedef {import("../data/cachedData.js").Question} Question */
@@ -134,6 +135,11 @@ function attachSubmitEvent(form) {
 
         const data = extractFormData(form);
 
+        if (!isFormValid(data)) {
+            toastNotification.showToast("Select at least 1 input", "error");
+            return;
+        }
+
         form.dispatchEvent(new CustomEvent("formSubmitted", { detail: data }));
     })
 }
@@ -152,4 +158,13 @@ function extractFormData(form) {
         hazardSelected: String(formData.get("hazard") || ""),
         specialNeedsSelected: formData.getAll("special_needs").map(String)
     }
+}
+
+/** @param {UserInput} data */
+function isFormValid(data) {
+    return (
+        data.locationSelected !== "" ||
+        data.hazardSelected !== "" ||
+        data.specialNeedsSelected.length > 0
+    )
 }


### PR DESCRIPTION
Prevent empty form submissions by adding a simple validation that requires at least one of location, hazard, or special needs to be selected. Imports toastNotification and uses it to show an error toast when validation fails. Adds isFormValid helper and updates the submit handler to return early instead of dispatching the formSubmitted event.

<img width="1920" height="938" alt="image" src="https://github.com/user-attachments/assets/ad34564d-bea0-4e6e-b32d-f0aedfe7ae69" />
