### PR TITLE
Potential Fix: Set z-index for iOS in form CSS (UNTESTED)

### DIFF
--- a/web/css/form.css
+++ b/web/css/form.css
@@ -116,6 +116,9 @@
     gap: 16px;
     border-top: 1px solid var(--toast-border);
     padding: 0;
+
+    /* For IOS */
+    z-index: 1;
 }
 
 .btn-submit {


### PR DESCRIPTION
Add z-index: 1 (with a "/* For IOS */" comment) to the form CSS rule to address stacking/visibility issues on iOS browsers where the element could be obscured. Keeps existing layout spacing and border rules unchanged.

Unsure if this will fix the issue. I don't have an iPhone, specifically, iPhone X and above, on Safari, to test it.